### PR TITLE
Re-locate action buttons on moderate panel

### DIFF
--- a/src/components/ModerationPanel/ContentSection/CommentSection/CommentSection.ts
+++ b/src/components/ModerationPanel/ContentSection/CommentSection/CommentSection.ts
@@ -62,11 +62,13 @@ export default class CommentSection {
     this.container = Build(Flex({ direction: "column" }), [
       [
         (this.actionsContainer = Flex({
+          direction: "row-reverse",
+          wrap: true,
           justifyContent: "space-between",
         })),
         [
           [
-            Flex(), // toggle buttons container
+            Flex({ marginTop: "xxs" }), // toggle buttons container
             [
               [
                 Flex(),

--- a/src/components/ModerationPanel/ContentSection/CommentSection/DeleteCommentsSection.ts
+++ b/src/components/ModerationPanel/ContentSection/CommentSection/DeleteCommentsSection.ts
@@ -38,7 +38,7 @@ export default class DeleteCommentsSection {
       }),
     });
 
-    this.main.actionsContainer.append(this.container);
+    this.main.actionsContainer.prepend(this.container);
   }
 
   ToggleDeleteSection() {

--- a/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/ActionButton.ts
+++ b/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/ActionButton.ts
@@ -6,8 +6,11 @@ import { TextElement } from "@style-guide/Text";
 import tippy from "tippy.js";
 import type QuickActionButtonsClassType from "../QuickActionButtons";
 
+type PositionType = "left" | "right";
+
 export default class ActionButton {
   main: QuickActionButtonsClassType;
+  #position: PositionType;
   buttonProps: ButtonPropsType;
   #tooltipContent: string | TextElement<"div">;
 
@@ -16,10 +19,12 @@ export default class ActionButton {
 
   constructor(
     main: QuickActionButtonsClassType,
+    position: PositionType,
     buttonProps: ButtonPropsType,
     tooltipContent?: string | TextElement<"div">,
   ) {
     this.main = main;
+    this.#position = position;
     this.buttonProps = buttonProps;
     this.#tooltipContent = tooltipContent;
 
@@ -47,26 +52,17 @@ export default class ActionButton {
         allowHTML: true,
         content: this.#tooltipContent,
         theme: "light",
-        // trigger: "manual",
       });
-
-      // TODO remove this comment
-      /* this.button.element.addEventListener("mouseenter", () => {
-        tp.show();
-      }); */
     }
 
     this.Show();
   }
 
-  Show(prepend?: boolean) {
-    if (!prepend) {
-      this.main.container.append(this.container);
-
-      return;
-    }
-
-    this.main.container.prepend(this.container);
+  Show() {
+    if (this.#position === "left")
+      this.main.leftActionButtonContainer.append(this.container);
+    else if (this.#position === "right")
+      this.main.rightActionButtonContainer.append(this.container);
   }
 
   Hide() {

--- a/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/ApproveButton.ts
+++ b/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/ApproveButton.ts
@@ -6,12 +6,14 @@ export default class ApproveButton extends ActionButton {
   constructor(main: QuickActionButtonsClassType) {
     super(
       main,
+      "left",
       {
-        type: "transparent",
+        type: "outline",
+        toggle: "mint",
         iconOnly: true,
         title: System.data.locale.common.moderating.approve,
         icon: new Icon({
-          size: 40,
+          size: 32,
           color: "mint",
           type: "verified",
         }),

--- a/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/AskForCorrectionButton.ts
+++ b/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/AskForCorrectionButton.ts
@@ -6,6 +6,7 @@ export default class AskForCorrectionButton extends ActionButton {
   constructor(main: QuickActionButtonsClassType) {
     super(
       main,
+      "left",
       {
         type: "outline",
         toggle: "blue",

--- a/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/ConfirmButton.ts
+++ b/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/ConfirmButton.ts
@@ -6,6 +6,7 @@ export default class ConfirmButton extends ActionButton {
   constructor(main: QuickActionButtonsClassType) {
     super(
       main,
+      "right",
       {
         type: "solid-mint",
         iconOnly: true,

--- a/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/DeleteButton.ts
+++ b/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/DeleteButton.ts
@@ -21,6 +21,7 @@ export default class DeleteButton extends ActionButton {
 
     super(
       main,
+      "right",
       {
         ...buttonProps,
         iconOnly: true,

--- a/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/MoreButton.ts
+++ b/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/MoreButton.ts
@@ -6,6 +6,7 @@ export default class MoreButton extends ActionButton {
   constructor(main: QuickActionButtonsClassType) {
     super(
       main,
+      "left",
       {
         type: "outline",
         toggle: "peach",

--- a/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/UnApproveButton.ts
+++ b/src/components/ModerationPanel/ContentSection/QuickActionButtons/ActionButton/UnApproveButton.ts
@@ -6,12 +6,13 @@ export default class UnApproveButton extends ActionButton {
   constructor(main: QuickActionButtonsClassType) {
     super(
       main,
+      "left",
       {
-        type: "transparent",
+        type: "outline",
         iconOnly: true,
         title: System.data.locale.common.moderating.unapprove,
         icon: new Icon({
-          size: 40,
+          size: 32,
           color: "dark",
           type: "verified",
         }),

--- a/src/components/ModerationPanel/ContentSection/QuickActionButtons/Answer.ts
+++ b/src/components/ModerationPanel/ContentSection/QuickActionButtons/Answer.ts
@@ -1,4 +1,3 @@
-import InsertBefore from "@root/helpers/InsertBefore";
 import type AnswerClassType from "../Answer";
 import ApproveButton from "./ActionButton/ApproveButton";
 import AskForCorrectionButton from "./ActionButton/AskForCorrectionButton";
@@ -26,14 +25,14 @@ export default class QuickActionButtonsForAnswer extends QuickActionButtons {
       return;
 
     if (this.askForCorrectionButton) {
-      this.askForCorrectionButton.Show(true);
+      this.askForCorrectionButton.Show();
 
       return;
     }
 
     this.askForCorrectionButton = new AskForCorrectionButton(this);
 
-    this.askForCorrectionButton.Show(true);
+    this.askForCorrectionButton.Show();
     this.askForCorrectionButton.container.ChangeMargin({
       marginRight: "xs",
     });
@@ -56,8 +55,6 @@ export default class QuickActionButtonsForAnswer extends QuickActionButtons {
       marginRight: "xs",
     });
 
-    InsertBefore(approveButton.container, this.moreButton.container);
-
     this.actionButtons.push(approveButton);
   }
 
@@ -69,8 +66,6 @@ export default class QuickActionButtonsForAnswer extends QuickActionButtons {
     unApproveButton.container.ChangeMargin({
       marginRight: "xs",
     });
-
-    InsertBefore(unApproveButton.container, this.moreButton.container);
 
     this.actionButtons.push(unApproveButton);
   }

--- a/src/components/ModerationPanel/ContentSection/QuickActionButtons/QuickActionButtons.ts
+++ b/src/components/ModerationPanel/ContentSection/QuickActionButtons/QuickActionButtons.ts
@@ -18,13 +18,16 @@ export type ButtonClassTypes =
 
 export default class QuickActionButtons {
   main: AnswerClassType | CommentClassType | QuestionClassType;
-  container: FlexElementType;
-  actionButtons: ButtonClassTypes[];
-  spinner: HTMLDivElement;
+  buttonSize: ButtonSizeType;
 
+  actionButtons: ButtonClassTypes[];
+
+  container: FlexElementType;
+  leftActionButtonContainer: FlexElementType;
+  rightActionButtonContainer: FlexElementType;
+  spinner: HTMLDivElement;
   selectedButton: ButtonClassTypes;
   confirmButton?: ConfirmButton;
-  buttonSize: ButtonSizeType;
   moreButton: MoreButton;
 
   constructor(
@@ -42,7 +45,18 @@ export default class QuickActionButtons {
   }
 
   private Render() {
-    this.container = Flex({ wrap: true, justifyContent: "flex-end" });
+    this.container = Flex({
+      wrap: true,
+      justifyContent: "space-between",
+      children: [
+        (this.leftActionButtonContainer = Flex({ wrap: true })),
+        (this.rightActionButtonContainer = Flex({
+          grow: true,
+          wrap: true,
+          justifyContent: "flex-end",
+        })),
+      ],
+    });
   }
 
   private RenderSpinner() {


### PR DESCRIPTION
**Before**:
![e37ca277-a6bc-498e-a090-0fe9e045aad3](https://user-images.githubusercontent.com/5789670/95056752-d5e55080-06fd-11eb-9c6a-b75edd72eea1.gif)


**After**(desktop version):
![bt (1)](https://user-images.githubusercontent.com/5789670/95056793-e695c680-06fd-11eb-88b7-e840aa2e3aff.gif)

**After**(mobile version):
![2a00ba70-b596-414b-8679-8f759437c7e3](https://user-images.githubusercontent.com/5789670/95056836-f2818880-06fd-11eb-988f-c456b2fc0c0b.gif)
