### PR TITLE
Emphasize users with special ranks and warn about moderators

### DIFF
--- a/src/controllers/Req/Brainly/Action/index.ts
+++ b/src/controllers/Req/Brainly/Action/index.ts
@@ -182,7 +182,7 @@ export type UsersDataInReportedContentsType = {
     names: string[];
     count: number;
   };
-  rank_ids?: number[];
+  ranks_ids?: number[];
   stats: {
     answers: number;
     comments: number;

--- a/src/controllers/System.ts
+++ b/src/controllers/System.ts
@@ -3,7 +3,7 @@
 import locale from "@root/locales";
 import ServerReq from "@ServerReq";
 import cookie from "js-cookie";
-import Action from "@BrainlyAction";
+import Action, { UserType } from "@BrainlyAction";
 import extensionConfig from "../configs/_/extension.json";
 import ArrayLast from "../helpers/ArrayLast";
 import storage from "../helpers/extStorage";
@@ -60,7 +60,7 @@ type ObjectAnyType = {
   [x: string]: any;
 };
 
-type RankDataType = {
+export type RankDataType = {
   color?: string;
   description?: string;
   id?: number;
@@ -312,10 +312,10 @@ class _System {
   };
 
   allModerators?: {
-    list: ObjectAnyType[];
-    withNicks: ObjectAnyType;
-    withID: ObjectAnyType;
-    withRanks: ObjectAnyType;
+    list: UserType[];
+    withNicks: { [nick: string]: UserType };
+    withID: { [userId: number]: UserType };
+    withRanks: { [rankId: number]: { [id: number]: UserType }[] };
   };
 
   routeMasks: {

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -79,7 +79,9 @@
           "text": "Take points back",
           "title": "Take points back from user"
         }
-      }
+      },
+      "contentAuthorIsModerator": "\"%{content_author}\" has moderation powers.\nPlease moderate this from the panel",
+      "contentAuthorHasSpecialRanks": "\"%{content_author}\" has \"%{special_rank}\" rank and might be someone who's important.\nPlease moderate this from the panel"
     },
     "personalNote": {
       "text": "Personal note",

--- a/src/locales/es_ES.json
+++ b/src/locales/es_ES.json
@@ -79,7 +79,9 @@
           "text": "Take points back",
           "title": "Take points back from user"
         }
-      }
+      },
+      "contentAuthorIsModerator": "\"%{content_author}\" has moderation powers.\nPlease moderate this from the panel",
+      "contentAuthorHasSpecialRanks": "\"%{content_author}\" has \"%{special_rank}\" rank and might be someone who's important.\nPlease moderate this from the panel"
     },
     "personalNote": {
       "text": "Personal note",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -79,7 +79,9 @@
           "text": "Reprendre les points",
           "title": "Reprendre les points"
         }
-      }
+      },
+      "contentAuthorIsModerator": "\"%{content_author}\" has moderation powers.\nPlease moderate this from the panel",
+      "contentAuthorHasSpecialRanks": "\"%{content_author}\" has \"%{special_rank}\" rank and might be someone who's important.\nPlease moderate this from the panel"
     },
     "personalNote": {
       "text": "Note personnelle",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -79,7 +79,9 @@
           "text": "Mengambil poin kembali",
           "title": "Mengambil kembali poin dari user"
         }
-      }
+      },
+      "contentAuthorIsModerator": "\"%{content_author}\" has moderation powers.\nPlease moderate this from the panel",
+      "contentAuthorHasSpecialRanks": "\"%{content_author}\" has \"%{special_rank}\" rank and might be someone who's important.\nPlease moderate this from the panel"
     },
     "personalNote": {
       "text": "Catatan pribadi",

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -79,7 +79,9 @@ export default {
           text: "Take points back",
           title: "Take points back from user"
         }
-      }
+      },
+      contentAuthorIsModerator: "\"%{content_author}\" has moderation powers.\nPlease moderate this from the panel",
+      contentAuthorHasSpecialRanks: "\"%{content_author}\" has \"%{special_rank}\" rank and might be someone who's important.\nPlease moderate this from the panel"
     },
     personalNote: {
       text: "Personal note",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -79,7 +79,9 @@
           "text": "Take points back",
           "title": "Take points back from user"
         }
-      }
+      },
+      "contentAuthorIsModerator": "\"%{content_author}\" has moderation powers.\nPlease moderate this from the panel",
+      "contentAuthorHasSpecialRanks": "\"%{content_author}\" has \"%{special_rank}\" rank and might be someone who's important.\nPlease moderate this from the panel"
     },
     "personalNote": {
       "text": "Personal note",

--- a/src/locales/pt_BR.json
+++ b/src/locales/pt_BR.json
@@ -79,7 +79,9 @@
           "text": "Take points back",
           "title": "Take points back from user"
         }
-      }
+      },
+      "contentAuthorIsModerator": "\"%{content_author}\" has moderation powers.\nPlease moderate this from the panel",
+      "contentAuthorHasSpecialRanks": "\"%{content_author}\" has \"%{special_rank}\" rank and might be someone who's important.\nPlease moderate this from the panel"
     },
     "personalNote": {
       "text": "Personal note",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -79,7 +79,9 @@
           "text": "Kazandığı puanları geri al",
           "title": "Kişinin sorudan kazandığı puanları geri al"
         }
-      }
+      },
+      "contentAuthorIsModerator": "\"%{content_author}\" kişisinin moderatör yetkisi var.\nLütfen işleme panelden devam et",
+      "contentAuthorHasSpecialRanks": "\"%{content_author}\" kişisinin \"%{special_rank}\" şeklinde özel rütbesi var ve önemli biri olabilir.\nLütfen işleme panelden devam et"
     },
     "personalNote": {
       "text": "Kişisel not",

--- a/src/scripts/views/12-QuestionAdd/_/ReportContents/Content/Content.ts
+++ b/src/scripts/views/12-QuestionAdd/_/ReportContents/Content/Content.ts
@@ -4,6 +4,7 @@ import Action, {
   RemoveCommentReqDataType,
   RemoveQuestionReqDataType,
   ReportedContentDataType,
+  UserDataInReportType,
   UsersDataInReportedContentsType,
 } from "@BrainlyAction";
 import CreateElement from "@components/CreateElement";
@@ -54,6 +55,13 @@ const CONTENT_TYPE_ICON_COLOR: {
   Comment: { type: "solid" },
 };
 
+type UserType = {
+  nick: string;
+  profileLink: string;
+  data: UsersDataInReportedContentsType;
+  specialRankColor?: string;
+};
+
 export default class Content {
   main: ReportedContentsType;
   data: ReportedContentDataType;
@@ -61,16 +69,8 @@ export default class Content {
   contentType: ContentNameType;
 
   users: {
-    reporter?: {
-      nick: string;
-      profileLink: string;
-      data: UsersDataInReportedContentsType;
-    };
-    reported: {
-      nick: string;
-      profileLink: string;
-      data: UsersDataInReportedContentsType;
-    };
+    reporter?: UserType;
+    reported: UserType;
   };
 
   dates: {
@@ -126,28 +126,49 @@ export default class Content {
     this.globalId = btoa(`${contentType.toLowerCase()}:${data.model_id}`);
 
     this.users = {
-      reporter: undefined,
-      reported: {
-        nick: (this.main.userData[data.user?.id || 0].nick || "").toLowerCase(),
-        profileLink: System.createProfileLink(
-          this.main.userData[data.user?.id || 0],
-        ),
-        data: this.main.userData[data.user?.id || 0],
-      },
+      reporter: this.PrepareUser(data.report?.user),
+      reported: this.PrepareUser(data.user),
     };
 
-    if (this.data.report)
-      this.users.reporter = {
-        nick: (
-          this.main.userData[data.report?.user?.id || 0].nick || ""
-        ).toLowerCase(),
-        profileLink: System.createProfileLink(
-          this.main.userData[data.report?.user?.id || 0],
-        ),
-        data: this.main.userData[data.report?.user?.id || 0],
-      };
-
     this.SetDates();
+  }
+
+  PrepareUser(userData: UserDataInReportType) {
+    if (!userData) return undefined;
+
+    const data = this.main.userData[userData?.id || 0];
+
+    const user: UserType = {
+      nick: (data.nick || "").toLowerCase(),
+      profileLink: System.createProfileLink(data),
+      data,
+    };
+
+    if (data.ranks_ids) {
+      const specialRankIdWithDifferentColor = data.ranks_ids.find(id => {
+        const rank =
+          System.data.Brainly.defaultConfig.config.data.ranksWithId[id];
+
+        if (!rank) return false;
+
+        return (
+          rank.type === 5 && rank.color !== "000000" && rank.color !== "000"
+        );
+      });
+      const rank =
+        System.data.Brainly.defaultConfig.config.data.ranksWithId[
+          specialRankIdWithDifferentColor
+        ];
+
+      if (rank) {
+        user.specialRankColor = rank.color;
+
+        if (!rank.color.startsWith("#"))
+          user.specialRankColor = `#${rank.color}`;
+      }
+    }
+
+    return user;
   }
 
   SetDates() {
@@ -306,6 +327,9 @@ export default class Content {
                                 target: "_blank",
                                 text: this.users.reported.data.nick,
                                 href: this.users.reported.profileLink,
+                                style: this.users.reported.specialRankColor && {
+                                  color: this.users.reported.specialRankColor,
+                                },
                               }),
                             ],
                             [
@@ -653,16 +677,19 @@ export default class Content {
         [
           [
             Flex(),
-            Text({
-              tag: "a",
-              size: "small",
-              weight: "bold",
-              target: "_blank",
-              breakWords: true,
-              text: this.users.reporter && this.users.reporter.data.nick,
-              href:
-                (this.users.reporter && this.users.reporter.profileLink) || "",
-            }),
+            this.users.reporter &&
+              Text({
+                tag: "a",
+                size: "small",
+                weight: "bold",
+                target: "_blank",
+                breakWords: true,
+                text: this.users.reporter.data.nick,
+                href: this.users.reporter.profileLink || "",
+                style: this.users.reporter.specialRankColor && {
+                  color: this.users.reporter.specialRankColor,
+                },
+              }),
           ],
           [
             Flex({

--- a/src/scripts/views/12-QuestionAdd/_/ReportContents/Content/Content.ts
+++ b/src/scripts/views/12-QuestionAdd/_/ReportContents/Content/Content.ts
@@ -10,6 +10,7 @@ import Action, {
 import CreateElement from "@components/CreateElement";
 import type { ContentNameType } from "@components/ModerationPanel/ModeratePanelController";
 import notification from "@components/notification2";
+import type { RankDataType } from "@root/controllers/System";
 import Build from "@root/helpers/Build";
 import HideElement from "@root/helpers/HideElement";
 import InsertAfter from "@root/helpers/InsertAfter";
@@ -18,7 +19,7 @@ import { Avatar, Box, Button, Flex, Icon, Spinner, Text } from "@style-guide";
 import type { BoxColorType } from "@style-guide/Box";
 import type { ButtonColorType } from "@style-guide/Button";
 import type { FlexElementType } from "@style-guide/Flex";
-import { IconColorType } from "@style-guide/Icon";
+import type { IconColorType } from "@style-guide/Icon";
 import type { TextElement } from "@style-guide/Text";
 import moment from "moment-timezone";
 import tippy, { Instance } from "tippy.js";
@@ -59,6 +60,7 @@ type UserType = {
   nick: string;
   profileLink: string;
   data: UsersDataInReportedContentsType;
+  specialRank?: RankDataType;
   specialRankColor?: string;
 };
 
@@ -149,11 +151,7 @@ export default class Content {
         const rank =
           System.data.Brainly.defaultConfig.config.data.ranksWithId[id];
 
-        if (!rank) return false;
-
-        return (
-          rank.type === 5 && rank.color !== "000000" && rank.color !== "000"
-        );
+        return rank?.type === 5;
       });
       const rank =
         System.data.Brainly.defaultConfig.config.data.ranksWithId[
@@ -161,10 +159,14 @@ export default class Content {
         ];
 
       if (rank) {
-        user.specialRankColor = rank.color;
+        user.specialRank = rank;
 
-        if (!rank.color.startsWith("#"))
-          user.specialRankColor = `#${rank.color}`;
+        if (rank.color !== "000000" && rank.color !== "000") {
+          user.specialRankColor = rank.color;
+
+          if (!rank.color.startsWith("#"))
+            user.specialRankColor = `#${rank.color}`;
+        }
       }
     }
 

--- a/src/scripts/views/12-QuestionAdd/_/ReportContents/Content/QuickDeleteButton.ts
+++ b/src/scripts/views/12-QuestionAdd/_/ReportContents/Content/QuickDeleteButton.ts
@@ -77,6 +77,37 @@ export default class QuickDeleteButton {
 
   async DeleteContent() {
     try {
+      const moderatorData =
+        System.allModerators?.withID[this.main.users.reported.data.id];
+
+      if (moderatorData) {
+        notification({
+          type: "info",
+          text: System.data.locale.common.moderating.contentAuthorIsModerator //
+            .replace(/%{content_author}/g, moderatorData.nick),
+        });
+
+        this.main.Moderate();
+
+        return;
+      }
+
+      if (this.main.users.reported.specialRank) {
+        notification({
+          type: "info",
+          text: System.data.locale.common.moderating.contentAuthorHasSpecialRanks
+            .replace(/%{content_author}/g, this.main.users.reported.data.nick)
+            .replace(
+              /%{special_rank}/g,
+              this.main.users.reported.specialRank.name,
+            ),
+        });
+
+        this.main.Moderate();
+
+        return;
+      }
+
       const message = System.data.locale.common.moderating.doYouWantToDeleteWithReason
         .replace("%{reason_title}", this.reason.title)
         .replace("%{reason_message}", this.reason.text);

--- a/src/scripts/views/12-QuestionAdd/_/ReportContents/ReportedContents.ts
+++ b/src/scripts/views/12-QuestionAdd/_/ReportContents/ReportedContents.ts
@@ -2,6 +2,7 @@ import type { UsersDataInReportedContentsType } from "@BrainlyAction";
 import Build from "@root/helpers/Build";
 import storage from "@root/helpers/extStorage";
 import InsertAfter from "@root/helpers/InsertAfter";
+import ServerReq from "@ServerReq";
 import { Flex } from "@style-guide";
 import type { FlexElementType } from "@style-guide/Flex";
 import type AnswerClassType from "./Content/Answer";
@@ -84,6 +85,8 @@ export default class ReportedContents {
     if (System.checkUserP(18)) {
       this.moderator = new Moderator(this);
     }
+
+    new ServerReq().GetAllModerators();
   }
 
   async SetLazyQueueDefaultValue() {

--- a/src/styles/pages/QuestionAdd.scss
+++ b/src/styles/pages/QuestionAdd.scss
@@ -9,6 +9,8 @@
 .flash-messages-container {
   top: 0;
   z-index: 9999;
+  // for seeing notifications after moderate panel has open
+  position: fixed;
 }
 
 .ext {


### PR DESCRIPTION
Moderators may encounter content who's the owner is a moderator or someone who's important. To avoid reduce of making mistakes, we will have these changes to have a safer and better approach.

**Changes on report box**
![image](https://user-images.githubusercontent.com/5789670/95685326-d9963d00-0bff-11eb-95bd-9b8914388e27.png)
Both users have special ranks and their nicknames have colored to emphasize.

### Changes on quick delete buttons:
When a moderator tries to use the quick delete button on the content of a moderator or a user who has special ranks; the extension will pop-up a warning message and will direct them to moderate from the panel.

**Trying to delete the content of the moderator:**

![5752d979-8c46-426c-8c2c-198b75ea4d82](https://user-images.githubusercontent.com/5789670/95685351-09dddb80-0c00-11eb-9cfa-d4643bb80d64.gif)

**Trying to delete the content of a user who has special ranks:**

![c57e605f-7522-4779-a571-12043225f3c3](https://user-images.githubusercontent.com/5789670/95685372-2a0d9a80-0c00-11eb-9cf2-b46ce8034cc9.gif)

